### PR TITLE
:sparkles: Added NewBasicAuthClientWithCustomHttpClient()

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.activeBackground": "#fa1b49",
+        "activityBar.background": "#fa1b49",
+        "activityBar.foreground": "#e7e7e7",
+        "activityBar.inactiveForeground": "#e7e7e799",
+        "activityBarBadge.background": "#155e02",
+        "activityBarBadge.foreground": "#e7e7e7",
+        "commandCenter.border": "#e7e7e799",
+        "sash.hoverBorder": "#fa1b49",
+        "statusBar.background": "#dd0531",
+        "statusBar.foreground": "#e7e7e7",
+        "statusBarItem.hoverBackground": "#fa1b49",
+        "statusBarItem.remoteBackground": "#dd0531",
+        "statusBarItem.remoteForeground": "#e7e7e7",
+        "titleBar.activeBackground": "#dd0531",
+        "titleBar.activeForeground": "#e7e7e7",
+        "titleBar.inactiveBackground": "#dd053199",
+        "titleBar.inactiveForeground": "#e7e7e799"
+    },
+    "peacock.color": "#dd0531"
+}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ the public API documentation is available at [robot.your-server.de](https://robo
 This fork is based on the repo of nl2go. The original repo implemented the important parts of Hetzner Robot API, but has not been updated since 2019. This work has the goal to keep up with API changes on Hetzner side and to implement additional functions that Hetzner Robot offers. 
 
 Contributions and feature requests are very welcome!
+
 ## Example
 
 ```go
@@ -33,3 +34,6 @@ func main() {
     fmt.Println(servers)
 }
 ```
+
+If you want to add instrumentation (for example to debug why you hit rate-limits of the Hetzner API) 
+you can use `NewBasicAuthClientWithCustomHttpClient()` to use your own httpClient.


### PR DESCRIPTION
Added NewBasicAuthClientWithCustomHttpClient().

If you want to add instrumentation (for example to debug why you hit rate-limits of the Hetzner API) you can use `NewBasicAuthClientWithCustomHttpClient()` to use your own httpClient.