### PR TITLE
:seedling: Add SetCredentials to RobotClient interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ the public API documentation is available at [robot.your-server.de](https://robo
 
 ## Infos about fork
 
-This fork is based on the repo of nl2go. The original repo implemented the important parts of Hetzner Robot API, but has not been updated since 2019. This work has the goal to keep up with API changes on Hetzner side and to implement additional functions that Hetzner Robot offers. 
+This fork is based on the repo of nl2go. The original repo implemented the important parts of Hetzner Robot API, but has not been updated since 2019. This work has the goal to keep up with API changes on Hetzner side and to implement additional functions that Hetzner Robot offers.
 
 Contributions and feature requests are very welcome!
 
@@ -35,5 +35,19 @@ func main() {
 }
 ```
 
-If you want to add instrumentation (for example to debug why you hit rate-limits of the Hetzner API) 
+If you want to add instrumentation (for example to debug why you hit rate-limits of the Hetzner API)
 you can use `NewBasicAuthClientWithCustomHttpClient()` to use your own httpClient.
+
+## Releasing
+
+Update version number in `client.go`
+
+```sh
+make test
+
+export RELEASE_TAG=vX.Y.Z
+
+git tag -a ${RELEASE_TAG} -m ${RELEASE_TAG}
+
+git push origin $RELEASE_TAG
+```

--- a/client.go
+++ b/client.go
@@ -11,9 +11,11 @@ import (
 	"github.com/syself/hrobot-go/models"
 )
 
-const baseURL string = "https://robot-ws.your-server.de"
-const version = "0.2.5"
-const userAgent = "hrobot-client/" + version
+const (
+	baseURL   string = "https://robot-ws.your-server.de"
+	version          = "0.2.5"
+	userAgent        = "hrobot-client/" + version
+)
 
 type Client struct {
 	Username   string
@@ -59,6 +61,18 @@ func (c *Client) ValidateCredentials() error {
 	if _, err := c.doGetRequest(c.baseURL); err != nil {
 		return err
 	}
+	return nil
+}
+
+func (c *Client) SetCredentials(username, password string) error {
+	if username == "" {
+		return fmt.Errorf("username cannot be empty")
+	}
+	if password == "" {
+		return fmt.Errorf("password cannot be empty")
+	}
+	c.Username = username
+	c.Password = password
 	return nil
 }
 

--- a/client.go
+++ b/client.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	baseURL   string = "https://robot-ws.your-server.de"
-	version          = "0.2.5"
+	version          = "0.2.6"
 	userAgent        = "hrobot-client/" + version
 )
 

--- a/interface.go
+++ b/interface.go
@@ -6,7 +6,7 @@ type RobotClient interface {
 	SetBaseURL(baseURL string)
 	SetUserAgent(userAgent string)
 	GetVersion() string
-
+	SetCredentials(username, password string) error
 	ValidateCredentials() error
 
 	ServerGetList() ([]models.Server, error)


### PR DESCRIPTION
Add SetCredentials to RobotClient interface.

Background: We want to enable hot-reload of credentials in the [Syself Hetzner ccm](https://github.com/syself/hetzner-cloud-controller-manager)
